### PR TITLE
chore: remove NRSDK dependency and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.immersal.core",
-  "version": "2.1.1",
+  "version": "2.1.1-xreal.2",
   "displayName": "Immersal SDK",
   "description": "Immersal Unity SDK is a toolkit for developing spatial augmented reality experiences with the Unity engine.",
   "unity": "2022.3",
@@ -16,8 +16,7 @@
     "com.unity.modules.ui": "1.0.0",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.render-pipelines.universal": "14.0.9",
-    "com.unity.ai.navigation": "1.1.5",
-    "com.xreal.nrsdk": "1.7.0"
+    "com.unity.ai.navigation": "1.1.5"
  },
  "keywords": [
     "augmented reality",


### PR DESCRIPTION
## Summary
- remove com.xreal.nrsdk dependency from manifest
- bump package version to 2.1.1-xreal.2

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f49096f14832a812c8961929ed5a4