### PR TITLE
Delay localization binding until SDK ready

### DIFF
--- a/Editor/XRMapEditor.cs
+++ b/Editor/XRMapEditor.cs
@@ -66,10 +66,13 @@ namespace Immersal.XR
             if (map.LocalizationMethod.IsNullOrDead())
             {
                 ImmersalLogger.LogWarning($"Map {map.name} has invalid localization method, resetting to DeviceLocalization.");
-                if (!TrySetLocalizationMethod(map, typeof(DeviceLocalization)))
+                if (ImmersalSDK.Instance == null || ImmersalSDK.Instance.Localizer == null)
                 {
-                    ImmersalLogger.LogError($"Failed. Uninitializing map {map.name}");
-                    map.Uninitialize();
+                    EditorApplication.delayCall += () => TrySetLocalizationMethod(map, typeof(DeviceLocalization));
+                }
+                else
+                {
+                    TrySetLocalizationMethod(map, typeof(DeviceLocalization));
                 }
             }
             
@@ -352,6 +355,12 @@ namespace Immersal.XR
                 ImmersalLogger.LogError("Invalid localization method assignment.");
                 MapManager.RefreshLocalizationMethods();
                 RefreshAvailableLocalizationMethods();
+                return false;
+            }
+
+            if (ImmersalSDK.Instance == null || ImmersalSDK.Instance.Localizer == null)
+            {
+                EditorApplication.delayCall += () => TrySetLocalizationMethod(map, localizationMethod);
                 return false;
             }
             


### PR DESCRIPTION
## Summary
- defer XRMap localization method assignment until Immersal SDK and localizer are available
- clean up automatic reset without logging an error when SDK is not ready

## Testing
- `npm test` *(fails: Missing script "test")*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f491c479c832abd421ad5cd8dfbd4