### PR TITLE
feat: enhance XREAL ARF logging

### DIFF
--- a/Runtime/Scripts/Util/ImmersalLogger.cs
+++ b/Runtime/Scripts/Util/ImmersalLogger.cs
@@ -12,6 +12,7 @@ Contact sales@immersal.com for licensing requests.
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.IO;
 using UnityEngine;
 
 namespace Immersal
@@ -28,6 +29,11 @@ namespace Immersal
         }
         
         public static LoggingLevel Level = LoggingLevel.All;
+
+        // File logging
+        private static bool m_LogToFile = false;
+        private static StreamWriter m_FileWriter;
+        private static readonly object m_FileLock = new object();
 
         private const bool m_IncludeCallerName = true;
         private const string m_AdditionalPrefix = "";
@@ -60,23 +66,69 @@ namespace Immersal
         }
         
         // note: filePath parameter is automagically included by System.Runtime.CompilerServices.CallerFilePath
-        
+
         public static void Log(string message, LoggingLevel messageLevel = LoggingLevel.All, [CallerFilePath] string filePath = "")
         {
             if (Level > messageLevel) return;
-            UnityEngine.Debug.Log(ProcessMessage(message, filePath));
+            string processed = ProcessMessage(message, filePath);
+            UnityEngine.Debug.Log(processed);
+            WriteToFile(processed);
         }
 
         public static void LogWarning(string message,  [CallerFilePath] string filePath = "")
         {
             if (Level > LoggingLevel.ErrorsAndWarnings) return;
-            UnityEngine.Debug.LogWarning(ProcessMessage(message, filePath));
+            string processed = ProcessMessage(message, filePath);
+            UnityEngine.Debug.LogWarning(processed);
+            WriteToFile(processed);
         }
 
         public static void LogError(string message, [CallerFilePath] string filePath = "")
         {
             if (Level > LoggingLevel.ErrorsOnly) return;
-            UnityEngine.Debug.LogError(ProcessMessage(message, filePath));
+            string processed = ProcessMessage(message, filePath);
+            UnityEngine.Debug.LogError(processed);
+            WriteToFile(processed);
+        }
+
+        public static void EnableFileLogging(bool enable, string filePath)
+        {
+            lock (m_FileLock)
+            {
+                if (enable)
+                {
+                    try
+                    {
+                        m_FileWriter = new StreamWriter(filePath, true);
+                        m_FileWriter.AutoFlush = true;
+                        m_LogToFile = true;
+                    }
+                    catch (Exception e)
+                    {
+                        m_LogToFile = false;
+                        UnityEngine.Debug.LogError($"Failed to enable file logging: {e.Message}");
+                    }
+                }
+                else
+                {
+                    m_LogToFile = false;
+                    if (m_FileWriter != null)
+                    {
+                        m_FileWriter.Flush();
+                        m_FileWriter.Close();
+                        m_FileWriter = null;
+                    }
+                }
+            }
+        }
+
+        private static void WriteToFile(string message)
+        {
+            if (!m_LogToFile || m_FileWriter == null) return;
+            lock (m_FileLock)
+            {
+                m_FileWriter.WriteLine($"{DateTime.Now:O} {message}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- log AR Foundation session start/stop, camera manager discovery, CPU image & intrinsics availability, frame details and active XR provider
- add optional file logging to ImmersalXREAL.log with inspector toggle

## Testing
- `npm test` (fails: Missing script: "test")
- `dotnet test` (fails: command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_e_688f491f4c4c832a9b0b58cb0959a42b