### PR TITLE
Guard XR management references

### DIFF
--- a/Runtime/Scripts/XR/Platforms/ARFoundationSupport.cs
+++ b/Runtime/Scripts/XR/Platforms/ARFoundationSupport.cs
@@ -18,7 +18,9 @@ using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using UnityEngine.XR.ARFoundation;
 using UnityEngine.XR.ARSubsystems;
+#if HAVE_XR_MANAGEMENT
 using UnityEngine.XR.Management;
+#endif
 
 namespace Immersal.XR
 {
@@ -119,8 +121,12 @@ namespace Immersal.XR
         public async Task<IPlatformConfigureResult> ConfigurePlatform(IPlatformConfiguration configuration)
         {
             ImmersalLogger.Log("XREAL AR Foundation session starting");
+#if HAVE_XR_MANAGEMENT
             string provider = XRGeneralSettings.Instance?.Manager?.activeLoader?.name ?? "Unknown";
             ImmersalLogger.Log($"Active XR provider: {provider}");
+#else
+            ImmersalLogger.Log("XR Management not available");
+#endif
             ImmersalLogger.Log("Configuring ARF Platform");
             
 #if UNITY_EDITOR


### PR DESCRIPTION
## Summary
- guard `UnityEngine.XR.Management` import and `XRGeneralSettings` usage behind `HAVE_XR_MANAGEMENT`
- fall back to a log message when XR Management is not available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_688fafb2ab8c832a817ab1b01afe5dc9