### PR TITLE
feat: add XR management references and defines

### DIFF
--- a/Runtime/Immersal.Core.asmdef
+++ b/Runtime/Immersal.Core.asmdef
@@ -4,6 +4,8 @@
         "Unity.XR.ARFoundation",
         "Unity.XR.ARSubsystems",
         "Unity.XR.CoreUtils",
+        "Unity.XR.Management",
+        "Unity.XR.OpenXR",
         "Unity.TextMeshPro"
     ],
     "includePlatforms": [],
@@ -18,6 +20,16 @@
             "name": "com.xreal.xr",
             "expression": "3.0.0-pre.1",
             "define": "IMMERSAL_XREAL"
+        },
+        {
+            "name": "com.unity.xr.management",
+            "expression": "4.0.0",
+            "define": "HAVE_XR_MANAGEMENT"
+        },
+        {
+            "name": "com.unity.xr.arfoundation",
+            "expression": "5.0.0",
+            "define": "HAVE_ARFOUNDATION"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
## Summary
- add Unity.XR.Management and Unity.XR.OpenXR to Immersal.Core assembly references
- define HAVE_XR_MANAGEMENT and HAVE_ARFOUNDATION version defines

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688fafb14d8c832a8aac500f705bbdad